### PR TITLE
fix: dont use latest as semrel-changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@actions/core": "^1.10.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@semantic-release/changelog": "latest",
+    "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/git": "^10.0.1",
     "@zeit/ncc": "^0.20.5",
     "action-gen": "1.1.6",


### PR DESCRIPTION
`latest` was accidentally committed