### PR TITLE
feat: update to node20

### DIFF
--- a/.actiongenrc.js
+++ b/.actiongenrc.js
@@ -36,7 +36,7 @@ module.exports = buildConfig({
     },
   ],
   runs: {
-    using: 'node16',
+    using: 'node20',
     main: 'dist/index.js',
   },
   usage: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Release

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   result:
     description: Result of the comparison.  Can be either passed or failed
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Adds support for node20 and removes the warning message that appears in the GitHub Actions Annotations UI when this action is used, as [Node v16 in GitHub Actions is pending deprecation](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20)

BREAKING CHANGE: Update to node20. 