### PR TITLE
ci: Ensure `node24` compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # positive tests to verify assertions work as expected
       - name: Setup Test Data
         id: test-data
@@ -139,16 +139,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag


### PR DESCRIPTION
* Bump actions/checkout to `v6` https://github.com/actions/checkout/releases
* Bump actions/setup-node to `v6` https://github.com/actions/setup-node/releases
* Bump cycjimmy/semantic-release-action to `v6` https://github.com/cycjimmy/semantic-release-action/releases
* Bump `node-version` to `24`